### PR TITLE
Make .delete background more visible

### DIFF
--- a/static/costituzione.css
+++ b/static/costituzione.css
@@ -1,5 +1,5 @@
 .delete {
-    background-color: #ffecec;
+    background-color: #fcacac;
     /* text-decoration: line-through; */
 }
 


### PR DESCRIPTION
The color used has too small contrast compared to the page background, so not easily visible.
