### PR TITLE
Fix issue#9

### DIFF
--- a/bin/issue9
+++ b/bin/issue9
@@ -1,0 +1,15 @@
+#! /bin/sh
+# Usage: $0 buggy.md >fixed.md
+test $# -eq 1 || { echo>&2 "Usage: $0 issue9.md >fixed.md"; exit 100; }
+# grep '\r'? no...
+cat "$1" | tr -d '\r' | cmp - "$1" || {
+        echo>&2 'This hack requires no \\r in the input, convert newlines'
+        exit 100
+}
+exec <"$1" || exit
+# HACK from https://unix.stackexchange.com/a/152389
+# since the proper solution is, well...
+tr '\n' '\r' | \
+        sed 's,\([^.]\)</del>\r\r<ins>,\1</del><ins>,g' | \
+        sed 's,\([^.]\)</ins>\r\r<del>,\1</ins><del>,g' | \
+        tr '\r' '\n'

--- a/diffs/Makefile
+++ b/diffs/Makefile
@@ -5,6 +5,7 @@ markdowns = $(patsubst %,%.md,$(diffs))
 
 2012-04-20-to-2016-01-20.md: ../2012-04-20/costituzione.md ../2016-01-20/costituzione.md
 	PATH=../bin:$$PATH ../bin/diff-by-article $^ > $@
+	../bin/issue9 $@ >temp && mv -f temp $@
 
 clean: diff-clean
 diff-clean:


### PR DESCRIPTION
Multiline substitutions are surprisingly clumsy, with or without perl,
so I trusted the least incomprehensible (if hackish) recipe from
stackoverflow; it's a hack which assumes no '\r' in the input file,
and checking that is *also* surprisingly clumsy, so I resorted
to checking that the file stays the same after deleting '\r'.

Any cleaner solution is welcome.